### PR TITLE
Fix for average velocity estimation

### DIFF
--- a/src/multirobotexploration/config/rendezvous_plan.yaml
+++ b/src/multirobotexploration/config/rendezvous_plan.yaml
@@ -25,9 +25,7 @@ K: [1,1,0,
     1,1,0,
     0,1,1,
     1,1,0,
-    1,1,0,
-    1,1,0,
-    0,1,1]
+    0,1,1,]
 
 # The W matrix represents the agreements activation weights.
 #
@@ -36,14 +34,12 @@ K: [1,1,0,
 #
 # For example, you can have an agreement [1,1,1] and the weights [0,0,0], which
 # in abstract math would imply in an instant agreement fulfillment activation.
-W: [60 , 60 , 0  ,
-    0  , 60 , 120,
-    120, 60 , 0  ,
-    0  , 60 , 120,
-    120, 120, 0  ,
-    120, 120, 0  ,
-    120, 120, 0  ,
-    0  , 120, 300]
+W: [100 , 100 , 0  ,
+    0   , 100 , 200,
+    300 , 200 , 0  ,
+    0   , 200 , 400,
+    400 , 300, 0  ,
+    0   , 300, 600]
 
 # The first rendezvous location is where all sub-teams
 # are supposed to meet first.

--- a/src/multirobotexploration/include/common/RendezvousPlan.h
+++ b/src/multirobotexploration/include/common/RendezvousPlan.h
@@ -50,6 +50,8 @@ class RendezvousPlan {
         // relization
         void RealizePlan(const int& robotId);
         void ResetPlanRealization();
+        void SetCurrentTime(const double& time);
+        double GetTimeLeftForCurrentAgreement();
         bool WasPlanRealized();
 
         std::vector<int>* GetPlanPtr();

--- a/src/multirobotexploration/include/nodes/Alysson2024Node.h
+++ b/src/multirobotexploration/include/nodes/Alysson2024Node.h
@@ -175,6 +175,8 @@ class Alysson2024Node {
         bool aDirty; /**< Used to initialize the basestation location in the main loop only once. */
         bool aFirst; /**< Used to skip the first delta time calculation to avoid major errors. */
         double aDeltaTime; /**< Delta time between iterations in the main loop. */
+        double aTotalTime;
+        double aTimeToReachNextRendezvous; /**< Time to reach the next rendezvous location. */
         Vec2i aOccPos; /**< The position of the robot in the Occupancy Grid reference frame. */
         ros::Time aLastTime; /**< The last capatured system time used to compute the dalta time. */
         tf::Vector3 aWorldPos; /**< The position of the robot in the world reference frame. */

--- a/src/multirobotexploration/include/nodes/AverageVelocityEstimatorNode.h
+++ b/src/multirobotexploration/include/nodes/AverageVelocityEstimatorNode.h
@@ -56,6 +56,7 @@ class AverageVelocityEstimatorNode {
         int aQueueSize;
         int aCount;
         bool aReceivedPosition;
+        bool aHasPreviousTime;
         double aRate;
         std::string aNamespace;
         tf::Vector3 aLastWorldPos;
@@ -85,4 +86,5 @@ class AverageVelocityEstimatorNode {
          * Helpers
          */
          std::deque<double> aVelocityArray;
+         ros::Time aLastTime;
 };

--- a/src/multirobotexploration/source/common/RendezvousPlan.cpp
+++ b/src/multirobotexploration/source/common/RendezvousPlan.cpp
@@ -63,6 +63,10 @@ RendezvousPlan::~RendezvousPlan() {
 
 }
 
+double RendezvousPlan::GetTimeLeftForCurrentAgreement() {
+    return current_timer;
+}
+
 void RendezvousPlan::PrintRealization() {
     printf("[RendezvousPlan] Realization: ");
     for(size_t robot=0; robot<currentPlanRealization.size(); ++robot) {
@@ -162,6 +166,10 @@ std::string RendezvousPlan::GenerateAgreementKey(const int& index) {
         key += std::to_string(val.participate);
     }
     return key;
+}
+
+void RendezvousPlan::SetCurrentTime(const double& time) {
+    current_timer = time;
 }
 
 void RendezvousPlan::InitializeLocation(tf::Vector3 location) {

--- a/src/multirobotexploration/source/localization/AverageVelocityEstimatorNode.cpp
+++ b/src/multirobotexploration/source/localization/AverageVelocityEstimatorNode.cpp
@@ -36,6 +36,8 @@ AverageVelocityEstimatorNode::AverageVelocityEstimatorNode() {
 
     // advertisers
     aAverageVelocityPublisher = node_handle.advertise<std_msgs::Float32>(aNamespace + "/average_velocity", aQueueSize);
+    aHasPreviousTime = false;
+    aReceivedPosition = false;
 
     // node's routines
     double update_period = PeriodToFreqAndFreqToPeriod(aRate);
@@ -71,16 +73,31 @@ double AverageVelocityEstimatorNode::ComputeAverageVelocity(std::deque<double>& 
 }
 
 void AverageVelocityEstimatorNode::Update() {
-    // compute moving average
-    if(aReceivedPosition) {
-        aAverageVelocityMsg.data = ComputeAverageVelocity(aVelocityArray);
-        aAverageVelocityPublisher.publish(aAverageVelocityMsg);
-    }
+    // Get current time
+    ros::Time current_time = ros::Time::now();
 
     // update velocities array
-    aVelocityArray.push_back(aWorldPos.distance(aLastWorldPos));
-    if(aVelocityArray.size() > aCount) aVelocityArray.pop_front();
-    aLastWorldPos = aWorldPos;    
+    if(aReceivedPosition) {
+        if(aHasPreviousTime) {
+            double distance = aWorldPos.distance(aLastWorldPos);
+            double time_diff = (current_time - aLastTime).toSec();
+            
+            if(time_diff > 0.001) {
+                // velocity = distance / per unit of time
+                double velocity = distance / time_diff;  
+                aVelocityArray.push_back(velocity);
+                if(aVelocityArray.size() > aCount) aVelocityArray.pop_front();
+            }
+
+            aAverageVelocityMsg.data = ComputeAverageVelocity(aVelocityArray);
+            aAverageVelocityPublisher.publish(aAverageVelocityMsg);
+        } else {
+            aHasPreviousTime = true;
+        }
+        
+        aLastWorldPos = aWorldPos;
+        aLastTime = current_time;
+    }
 }
 
 int main(int argc, char* argv[]) {

--- a/src/multirobotexploration/source/policies/Alysson2024Node.cpp
+++ b/src/multirobotexploration/source/policies/Alysson2024Node.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Alysson2024Node.h"
+#include "SearchAlgorithms.h"
 
 Alysson2024Node::Alysson2024Node() {
     ros::NodeHandle node_handle("~");
@@ -162,6 +163,9 @@ Alysson2024Node::Alysson2024Node() {
     aPlanRealizationPublisher = node_handle.advertise<multirobotsimulations::rendezvous>(aNamespace + "/realizing_plan", aQueueSize);
     aPlanLocationPublisher = node_handle.advertise<multirobotsimulations::CustomPose>(aNamespace + "/plan_updater", aQueueSize);
 
+    aTotalTime = 0.0;
+    aTimeToReachNextRendezvous = aPlan->GetCurrentAgreementTimer();
+
     // Node's routines
     double update_period = PeriodToFreqAndFreqToPeriod(aRate);
     aTimers.push_back(node_handle.createTimer(ros::Duration(update_period), std::bind(&Alysson2024Node::Update, this)));
@@ -205,6 +209,7 @@ void Alysson2024Node::CSpaceCallback(nav_msgs::OccupancyGrid::ConstPtr msg) {
     if(!aHasOcc) aHasOcc = true;
     aCSpaceMsg.info = msg->info;
     aCSpaceMsg.header = msg->header;
+    aCSpaceMsg.data.assign(msg->data.begin(), msg->data.end());
 }
 
 void Alysson2024Node::SetIdleCallback(std_msgs::String::ConstPtr msg) {
@@ -459,6 +464,7 @@ void Alysson2024Node::Update() {
             aPlan->UpdateCurrentAgreementLocation(aGoalFrontier);
             aPlan->ResetPlanRealization();
             aPlan->SetNextAgreement();
+            aTimeToReachNextRendezvous += aPlan->GetCurrentAgreementTimer();
 
             ROS_INFO("[Alysson2024Node] New location selected [%f %f], sending to others.",
                 aGoalFrontier.getX(), aGoalFrontier.getY());
@@ -489,6 +495,7 @@ void Alysson2024Node::Update() {
                 ChangeState(state_compute_centroids);
                 aReceivedNewRendezvousLocation = false;
                 aTimeWaiting = 0.0;
+                aTimeToReachNextRendezvous += aPlan->GetCurrentAgreementTimer();
             } else {
                 ROS_INFO("[Alysson2024Node] Waiting for new rendezvous location for %fs", aTimeWaiting);
 
@@ -498,6 +505,7 @@ void Alysson2024Node::Update() {
                     ChangeState(state_compute_centroids);
                     ROS_INFO("[Alysson2024Node] Consensus seems to have died, reseting to next plan.");
                     aTimeWaiting = 0.0;
+                    aTimeToReachNextRendezvous += aPlan->GetCurrentAgreementTimer();
                 }
             }
 
@@ -515,6 +523,8 @@ void Alysson2024Node::Update() {
         aPlan->PrintCurrent();   
     }
         
+
+
     // follow the rendezgous policy only if
     // has something to explore, otherwise,
     // let robots go back to base
@@ -523,6 +533,46 @@ void Alysson2024Node::Update() {
         aCurrentState != state_idle &&
         FinishedMission() == false) {
         ChangeState(state_set_rendezvous_location);
+    } 
+
+    if(aCurrentState < state_set_rendezvous_location &&
+        aCurrentState != state_idle) {
+        // new policy, set current timer to 0.0 
+        // in case the robot is going to take
+        // to much time to reach the next location
+        // this is a method to reduce waiting time
+        // at rendezvous locations
+        aGoalRendezvous = aPlan->GetCurrentAgreementLocation();
+        Vec2i next_rendezvous_occ_pos;
+        WorldToMap(aCSpaceMsg, aGoalRendezvous, next_rendezvous_occ_pos);
+        std::list<Vec2i> path;
+        sa::ComputePath(aCSpaceMsg, aOccPos, next_rendezvous_occ_pos, path);
+        double path_length_meters = 0.0;
+        double expected_speed = 0.5;
+        double expected_heuristic_error = 3.0;
+        if(!path.empty()) {
+            auto it = path.begin();
+            Vec2i prev = *it;
+            ++it;
+            for(; it != path.end(); ++it) {
+                Vec2i current = *it;
+                double segment_length = sqrt(pow(current.x - prev.x, 2) + pow(current.y - prev.y, 2));
+                path_length_meters += segment_length * aCSpaceMsg.info.resolution;
+                prev = current;
+            }
+        } else {
+            double heuristic_distance = sqrt(Distance(next_rendezvous_occ_pos, aOccPos));
+            path_length_meters = heuristic_distance * expected_heuristic_error * aCSpaceMsg.info.resolution;
+        }
+        double time_to_reach_next_rendezvous = path_length_meters / expected_speed;
+        double time_diff = aTimeToReachNextRendezvous - aTotalTime;
+        double heuristic = time_diff - time_to_reach_next_rendezvous;
+        ROS_INFO("[Alysson2024Node] Next rendezvous (heuristic): %f/%f/%f/%f/%f", 
+            aTimeToReachNextRendezvous, aTotalTime, time_diff, time_to_reach_next_rendezvous, heuristic);
+        if(heuristic <= 0.0) {
+            aPlan->SetCurrentTime(-1.0);
+            ROS_INFO("[Alysson2024Node] Resetting timer to -1.0, this will force the robot to wait at rendezvous location.");
+        }
     }
 
     aDeltaTime = ros::Time::now().sec - aLastTime.sec;
@@ -530,6 +580,9 @@ void Alysson2024Node::Update() {
 
     // run spin to get the data
     aLastTime = ros::Time::now();
+
+    // consider that this updates at 1hz
+    aTotalTime += 1.0;
 
     if(aFirst) aFirst = false;
 }


### PR DESCRIPTION
- Added time into the velocity computation. Forgot to divide the distances traveled by time to get the average velocity, this is not detrimental, but it is fundamentaly wrong.
- Added a differente example rendezvous plan.
- Added some tweaks into the node's policy